### PR TITLE
vimc-3459: logging for barman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+logs

--- a/scripts/schedule-barman-montagu-nightly
+++ b/scripts/schedule-barman-montagu-nightly
@@ -12,8 +12,19 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+ROOT_BARMAN_MONTAGU=$(dirname $(readlink $PATH_BARMAN_MONTAGU))
+LOGDIR="$ROOT_BARMAN_MONTAGU/logs"
+LOGPATH="$ROOT_BARMAN_MONTAGU/logs/barman.log"
+
 echo "Found bb8 at: $PATH_BB8"
 echo "Found barman-montagu at: $PATH_BARMAN_MONTAGU"
+echo "Logging to: $LOGDIR"
+
+if [ ! -f $LOGPATH ]; then
+    mkdir -p $LOGDIR
+    touch $LOGPATH
+    chown -R montagu.montagu $LOGDIR
+fi
 
 DEST=/etc/cron.daily/barman-monatgu-nightly
 
@@ -21,10 +32,24 @@ echo "Writing cron job to $DEST"
 cat <<EOF > "$DEST"
 #!/usr/bin/env bash
 set -e
+exec &>> $LOGPATH
 $PATH_BARMAN_MONTAGU update-nightly
 $PATH_BB8 backup
 EOF
 
+echo "Creating logrotate configuration"
+cat <<EOF > /etc/logrotate.d/barman
+$LOGPATH {
+  rotate 3
+  weekly
+  compress
+  delaycompress
+  missingok
+  notifempty
+  create 644 montagu montagu
+}
+EOF
+
 echo "You can test this by running"
 echo
-echo "    run-parts -v –-test /etc/cron.daily"
+echo "    run-parts -v --test /etc/cron.daily"


### PR DESCRIPTION
This is untested, but my reading suggests that it should work.

Basically: cron is not logging anything for us.  See https://askubuntu.com/questions/56683/where-is-the-cron-crontab-log - running this produces in `/var/log/syslog`

```
Feb 24 06:25:01 wpia-didess1 CRON[2320]: (root) CMD (test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily ))
```

but basically nothing else. One must be root to even see this.

The PR here works out where the source directory of barman is (using `readlink`) and arranges to write logs there with the redirect at the start of the file (`exec &>> $LOGPATH`) - this appears to be more bash black magic but works as expected for me in this example script:

```
#!/usr/bin/env bash
exec &>> log.log

echoerr() { echo "$@" 1>&2; }
echo "hello stdout world"
echoerr "hello stderr world"
```

The other bit of weirdness here is the logrotate configuration - this will ideally rotate and delete logs weekly, compressing after 1 week.